### PR TITLE
For datasets we may return nothing

### DIFF
--- a/src/gmtmex_parser.c
+++ b/src/gmtmex_parser.c
@@ -220,8 +220,10 @@ static void *gmtmex_get_dataset (void *API, struct GMT_DATASET *D) {
 	struct GMT_DATASEGMENT *S = NULL;
 	mxArray *D_struct = NULL, *mxheader = NULL, *mxdata = NULL, *mxtext = NULL, *mxstring = NULL;
 
-	if (D == NULL)	/* Safety valve */
-		mexErrMsgTxt ("gmtmex_get_dataset: programming error, output DATASET D is empty\n");
+	if (D == NULL) {	/* No output produced (?) - return a null data set */
+		D_struct = mxCreateStructMatrix (0, 0, N_MEX_FIELDNAMES_DATASET, GMTMEX_fieldname_dataset);
+		return (D_struct);
+	}
 	
 	for (tbl = seg_out = 0; tbl < D->n_tables; tbl++)	/* Count non-zero segments */
 		for (seg = 0; seg < D->table[tbl]->n_segments; seg++)
@@ -1308,7 +1310,8 @@ void GMTMEX_Set_Object (void *API, struct GMT_RESOURCE *X, const mxArray *ptr) {
 
 void *GMTMEX_Get_Object (void *API, struct GMT_RESOURCE *X) {
 	mxArray *ptr = NULL;
-	if ((X->object = GMT_Read_VirtualFile (API, X->name)) == NULL)
+	/* In line-by-line modules it is possible no output is produced, hence we make an exception for DATASET: */
+	if ((X->object = GMT_Read_VirtualFile (API, X->name)) == NULL && X->family != GMT_IS_DATASET)
 		mexErrMsgTxt ("GMT: Error reading virtual file from GMT\n");
 	switch (X->family) {	/* Determine what container we got */
 		case GMT_IS_GRID:	/* A GMT grid; make it the pos'th output item */

--- a/src/gmtmex_parser.c
+++ b/src/gmtmex_parser.c
@@ -99,14 +99,14 @@ int GMTMEX_print_func (FILE *fp, const char *message) {
 	return 0;
 }
 
-static int gmtmex_getMNK (const mxArray *p, int which) {
+static uint64_t gmtmex_getMNK (const mxArray *p, int which) {
 	/* Get number of columns or number of bands of a mxArray.
 	   which = 0 to inquire n_rows
 	         = 1 to inquire n_columns
 	         = 2 to inquire n_bands
 	         = ? ERROR
 	*/
-	int nx, ny, nBands, nDims;
+	uint64_t nx, ny, nBands, nDims;
 	const mwSize *dim_array = NULL;
 
 	nDims     = mxGetNumberOfDimensions(p);
@@ -125,7 +125,7 @@ static int gmtmex_getMNK (const mxArray *p, int which) {
 		return nBands;
 	else
 		mexErrMsgTxt("gmtmex_getMNK: Bad dimension number!");
-	return -1;
+	return 0;
 }
 
 static void gmtmex_quit_if_missing (const char *function, const char *field) {


### PR DESCRIPTION
If that happens we must create an empty dataset in matlab and return it.

The example @joa-quim tried was

D = gmtmex('gmtselect -R0/3/0/3', [2 -2])

which crashed.  Now, it passes but we still get an annoying Error from the GMT API as it cannot find the non-existent dataset.  We can live with this for now.  After this pull request we get

>> D = gmtmex('gmtselect -R0/3/0/3', [2 -2])
[Session Matlab (0)]: Error returned from GMT API: GMT_OBJECT_NOT_FOUND (59)

D = 

  0x0 empty struct array with fields:

    data
    text
    header
    comment
    proj4
    wkt
