### PR TITLE
Use the new GMT_Free function for 6.2.x and onwards

### DIFF
--- a/src/gmtmex.c
+++ b/src/gmtmex.c
@@ -404,7 +404,10 @@ void mexFunction (int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 				if (X[kk].object == ppp) X[kk].object = NULL;
 		}
 	}
-	free (X);
+#if GMT_MAJOR_VERSION == 6 && GMT_MINOR_VERSION > 1
+	/* Before we just let the memory leak... */
+	GMT_Free (API, X);
+#endif
 
 	/* 9. Destroy linked option list */
 


### PR DESCRIPTION
This fixes the problem reported earlier about Windows crash when freeing the pointer for GMT 6.2.x or later.
