### PR TITLE
Complete the Cube handling

### DIFF
--- a/src/gmtmex.h
+++ b/src/gmtmex.h
@@ -144,8 +144,8 @@ static const char *GMTMEX_fieldname_dataset[N_MEX_FIELDNAMES_DATASET] =
 
 #define N_MEX_FIELDNAMES_CUBE	19
 static const char *GMTMEX_fieldname_cube[N_MEX_FIELDNAMES_CUBE] =
-	{"w", "x", "y", "z", "range", "inc", "registration", "nodata", "title", "comment",
-	 "command", "datatype", "x_unit", "y_unit", "z_unit", "w_unit", "layout", "proj4", "wkt"};
+	{"v", "x", "y", "z", "range", "inc", "registration", "nodata", "title", "comment",
+	 "command", "datatype", "x_unit", "y_unit", "z_unit", "v_unit", "layout", "proj4", "wkt"};
 
 /* GMT_IS_GRID:
  * Returned by GMT via the parser as a MEX structure with the

--- a/src/gmtmex.h
+++ b/src/gmtmex.h
@@ -21,7 +21,7 @@
 #define GMTMEX_H
 
 #define GMTMEX_MAJOR_VERSION 2
-#define GMTMEX_MINOR_VERSION 0
+#define GMTMEX_MINOR_VERSION 1
 #define GMTMEX_PATCH_VERSION 0
 
 /* Define the minimum GMT version suitable for this GMTMEX version */
@@ -106,6 +106,7 @@ typedef int mwSize;
 #	define MEXM_IJ(M,row,col) ((row)*M->n_columns + (col))
 	/* And this on GMT_GRID */
 #	define MEXG_IJ(M,row,col) ((row)*M->header->n_columns + (col))
+	/* And this on GMT_CUBE */
 #	define MEXU_IJK(M,layer,row,col) ((layer)*M->header->nm + (row)*M->header->n_columns + (col))
 #else	/* Here we go for Matlab or Octave(mex) */
 #	ifdef GMT_MATLAB
@@ -119,6 +120,7 @@ typedef int mwSize;
 #	define MEXM_IJ(M,row,col) ((col)*M->n_rows + (row))
 	/* And this on GMT_GRID */
 #	define MEXG_IJ(M,row,col) ((col)*M->header->n_rows + M->header->n_rows - (row) - 1)
+	/* And this on GMT_CUBE */
 #	define MEXU_IJK(M,layer,row,col) ((layer)*M->header->nm + (col)*M->header->n_rows + M->header->n_rows - (row) - 1)
 #endif
 
@@ -128,9 +130,9 @@ typedef int mwSize;
 /* GMT_IS_DATASET:
  * Returned by GMT via the parser as a MEX structure with the
  * fields listed below.  Pure datasets will only set the data
- * matrix and leave the text cell array empty, while textsets
- * will fill out both.  Only the first segment will have any
- * information in the info and projection_ref_* items.  */
+ * matrix and leave the text cell array empty, while datasets
+ * with trailing text will fill out both.  Only the first segment
+ * will have any information in the info and projection_ref_* items.  */
 
 #define N_MEX_FIELDNAMES_DATASET	6
 static const char *GMTMEX_fieldname_dataset[N_MEX_FIELDNAMES_DATASET] =
@@ -179,7 +181,7 @@ static const char *GMTMEX_fieldname_cpt[N_MEX_FIELDNAMES_CPT] =
 static const char *GMTMEX_fieldname_ps[N_MEX_FIELDNAMES_PS] =
 	{"postscript", "length", "mode", "comment"};
 
-/* Macro for indexing into a GMT grid [with pad] */
+/* Macro for indexing into an internal GMT grid [with pad] */
 #define GMT_IJP(h,row,col) ((uint64_t)(((int64_t)(row)+(int64_t)h->pad[GMT_YHI])*((int64_t)h->mx)+(int64_t)(col)+(int64_t)h->pad[GMT_XLO]))
 
 #define MODULE_LEN 	32	/* Max length of a GMT module name */

--- a/src/gmtmex_parser.c
+++ b/src/gmtmex_parser.c
@@ -637,7 +637,7 @@ static struct GMT_CUBE *gmtmex_cube_init (void *API, unsigned int direction, uns
 			unsigned int pad = (unsigned int)GMT_NOTSET;
 			uint64_t *this_dim = NULL, dims[3] = {0, 0, 0};
 			char x_unit[GMT_GRID_VARNAME_LEN80] = { "" }, y_unit[GMT_GRID_VARNAME_LEN80] = { "" },
-			     z_unit[GMT_GRID_VARNAME_LEN80] = { "" }, w_unit[GMT_GRID_VARNAME_LEN80] = { "" }, layout[3];
+			     z_unit[GMT_GRID_VARNAME_LEN80] = { "" }, v_unit[GMT_GRID_VARNAME_LEN80] = { "" }, layout[3];
 			mx_ptr = mxGetField (ptr, 0, "inc");
 			if (mx_ptr == NULL)
 				mexErrMsgTxt ("gmtmex_cube_init: Could not find inc array with Cube increments\n");
@@ -648,7 +648,7 @@ static struct GMT_CUBE *gmtmex_cube_init (void *API, unsigned int direction, uns
 				mexErrMsgTxt ("gmtmex_cube_init: Could not find range array for Cube range\n");
 			range = mxGetData (mx_ptr);
 
-			mxCube = mxGetField(ptr, 0, "w");
+			mxCube = mxGetField(ptr, 0, "v");
 			if (mxCube == NULL)
 				mexErrMsgTxt ("gmtmex_cube_init: Could not find data array for Cube\n");
 			if (!mxIsSingle(mxCube) && !mxIsDouble(mxCube))
@@ -682,7 +682,7 @@ static struct GMT_CUBE *gmtmex_cube_init (void *API, unsigned int direction, uns
 				mexErrMsgTxt ("gmtmex_cube_init: Failure to alloc GMT source Cube for input\n");
 
 			if (this_dim) {	/* If not equidistant we must duplicate the level array into the Cube manually */
-				if (U->z == NULL && GMT_Put_Levels (API, U, z, dim[2]))
+				if (U->z == NULL && GMT_Put_Levels (API, U, z, dims[2]))
 					mexErrMsgTxt ("gmtmex_cube_init: Failure to put non-equidistant z-nodes into the cube structure\n");
 			}
 
@@ -747,9 +747,9 @@ static struct GMT_CUBE *gmtmex_cube_init (void *API, unsigned int direction, uns
 				mxGetString(mx_ptr, z_unit, (mwSize)mxGetN(mx_ptr) + 1);
 				strncpy(U->units, z_unit, GMT_GRID_VARNAME_LEN80 - 1);
 			}
-			mx_ptr = mxGetField (ptr, 0, "w_unit");
+			mx_ptr = mxGetField (ptr, 0, "v_unit");
 			if (mx_ptr != NULL) {
-				mxGetString(mx_ptr, w_unit, (mwSize)mxGetN(mx_ptr) + 1);
+				mxGetString(mx_ptr, v_unit, (mwSize)mxGetN(mx_ptr) + 1);
 				strncpy(U->header->z_units, z_unit, GMT_GRID_VARNAME_LEN80 - 1);
 			}
 			mx_ptr = mxGetField (ptr, 0, "layout");
@@ -1538,7 +1538,7 @@ char GMTMEX_objecttype (const mxArray *ptr) {
 	if (mxIsEmpty (ptr))
 		mexErrMsgTxt ("GMTMEX_objecttype: Pointer is empty\n");
 	if (mxIsStruct (ptr)) {	/* This means either a cube, dataset, grid, image, cpt, or PS, so must check for fields */
-		mx_ptr = mxGetField (ptr, 0, "w_unit");
+		mx_ptr = mxGetField (ptr, 0, "v_unit");
 		if (mx_ptr) return 'u';
 		mx_ptr = mxGetField (ptr, 0, "data");
 		if (mx_ptr) return 'd';


### PR DESCRIPTION
**Description of proposed changes**

Several more issues needed to be addressed:

1. To export non-equidistant cube layers we must pass inc[2] = 0 and set dim[2] instead, then place the layer values later via _GMT_Put_Layers_ (same procedure as **grdinterpolate** does when creating such cubes).
2. Update mex version to 2.1.0
3. Like in GMT CLI use v for the cube value instead of w.
