### PR TITLE
Clean up some version-specific text

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,8 +28,8 @@ help::
 #!
 
 opt:
-		@echo "[Running `ls /Applications/GMT-6.3.?.app/Contents/Resources/share/tools/gmt_prepmex.sh | tail -1`]"; echo ""
-		@`/Applications/GMT-6.3.?.app/Contents/Resources/share/tools/gmt_prepmex.sh | tail -1`
+		@echo "[Running `ls /Applications/GMT-6.4.?.app/Contents/Resources/share/tools/gmt_prepmex.sh | tail -1`]"; echo ""
+		@`/Applications/GMT-6.4.?.app/Contents/Resources/share/tools/gmt_prepmex.sh | tail -1`
 
 latest-config:
 		curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" -s -R -o config.sub

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GMTMex - GMT API for MATLAB
+# GMT/MEX - GMT API for MATLAB
 
 # Extended Docs
 
@@ -16,18 +16,18 @@ Examples below will give you the general idea.
 ## Windows
 
 The Windows installers come already with the gmtmex.mexw64|32 and gmt.m files necessary run the MEX. Only make sure that the
-GMT6.3 binary dir is either in the Windows path (the installer does that for you) and in the MATLAB path (you have to do it
+GMT6.4 binary dir is either in the Windows path (the installer does that for you) and in the MATLAB path (you have to do it
 yourself). If you want to (re)build the MEX file yourself, see the compile_mex.bat in the source SVN repository.
 
-## OS X
+## macOS
 
-We have successfully built the MATLAB interface under OS X. However, due to the way MATLAB handles shared libraries it is a
+We have successfully built the MATLAB interface under macOS. However, due to the way MATLAB handles shared libraries it is a
 delicate process, with several caveats. This may change over time as we work with MathWorks to straighten out the kinks.
 The following works:
 
- * Install the GMT OS X Bundle
+ * Install the GMT macOS Bundle
  * Run the gmt_prepmex.sh script in the bundle's share/tools directory.  This will duplicate
-   the GMT 6.3 installation into /opt/gmt and re-baptize all the shared libraries.
+   the GMT 6.4 installation into /opt/gmt and re-baptize all the shared libraries.
  * Use gmtswitch to make /opt/gmt the current active GMT version
  * Checkout the gmtmex project via git into some directory, i.e.,
    ```

--- a/src/gmt.m
+++ b/src/gmt.m
@@ -2,7 +2,7 @@ function varargout = gmt(cmd, varargin)
 % Helper function to call the gmtmex MEX function
 
 	if (nargin == 0)
-		fprintf(sprintf('\n\t\tGMT - The Generic Mapping Tools, Version 6.3 API\n'))
+		fprintf(sprintf('\n\t\tGMT - The Generic Mapping Tools, Version 6.4 API\n'))
 		fprintf(sprintf('Copyright 1991-2021 The GMT Team (https://www.generic-mapping-tools.org/team.html\n\n'))
 	
 		fprintf(sprintf('Usage:\tTo call a GMT module:\n\t    output = gmt (''module_name'', ''options'', numeric_input)\n\n'))


### PR DESCRIPTION
Had a mix of 6.3 and old names for OS X (now macOS).
